### PR TITLE
Private alias method

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ class Bar
   private_attr_accessor :foo
   private_attr_reader :baz
   private_attr_writer :bat
+  private_alias_method :bar, :foo
 
   def initialize foo
     self.foo = foo

--- a/lib/private_attr.rb
+++ b/lib/private_attr.rb
@@ -32,4 +32,9 @@ module PrivateAttr
     attr_writer(*attr)
     protected(*attr.map { |a| "#{a}=" })
   end
+
+  def private_alias_method(new_name, old_name)
+    alias_method(new_name, old_name)
+    private(new_name)
+  end
 end

--- a/spec/private_attr_spec.rb
+++ b/spec/private_attr_spec.rb
@@ -182,7 +182,7 @@ describe PrivateAttr do
             super.upcase
           end
         end
-        Class.new(PrivateDummy).include(mod)
+        Class.new(PrivateDummy).send(:include, mod)
       end
 
       it 'allows alias to be called internally' do


### PR DESCRIPTION
This is a pull request against our own salsify-master branch.

This adds the only method (`private_alias_method`) that was part of our local implementation, but not present in the gem.

Prime: @jturkel 
